### PR TITLE
Removes DPAD access check for species data

### DIFF
--- a/app/components/species/index.tsx
+++ b/app/components/species/index.tsx
@@ -32,7 +32,6 @@ import { useSpeciesContext } from '$components/common/app-context';
 import { getColorLegend } from '$utils/data/color';
 import { MdContent } from '$components/common/md-content';
 import { HealpixArrowDestineData } from '$utils/data/healpix';
-import { useKeycloak } from '$components/auth/context';
 
 const ChartsSection = React.lazy(() => import('./charts'));
 
@@ -59,7 +58,6 @@ export default function Component(props: SpeciesComponentProps) {
   const {
     params: { id }
   } = props;
-  const { hasDPADAccess } = useKeycloak();
   const { group, setGroup, setDestineYear, destineLayer } = useSpeciesContext();
 
 
@@ -69,7 +67,6 @@ export default function Component(props: SpeciesComponentProps) {
   });
 
   const { data: seasonalData } = useQuery({
-    enabled: hasDPADAccess,
     queryKey: ['species', id, 'csv'],
     queryFn: getCsvFn(`/destine/ifs-nemo-${id}-weighted-seasonal.csv`),
     select: selectCsvChartData
@@ -87,7 +84,7 @@ export default function Component(props: SpeciesComponentProps) {
     queryFn: requestSpeciesArrowFn(group?.file)
   });
 
-  const destineDataEnabled = !!group?.id && hasDPADAccess && !!destineLayer;
+  const destineDataEnabled = !!group?.id && !!destineLayer;
   const { data: destineArrowData } = useQuery({
     enabled: destineDataEnabled,
     queryKey: ['species', id, 'arrow-destine', group?.id],

--- a/app/components/species/map-data.tsx
+++ b/app/components/species/map-data.tsx
@@ -11,11 +11,9 @@ import { DeckGLOverlay } from '$components/common/deckgl-overlay';
 import { useSpeciesContext } from '$components/common/app-context';
 import { getJsonFn, Species } from '$utils/api';
 import { MapLoadingIndicator } from '$components/common/map-loading-indicator';
-import { useKeycloak } from '$components/auth/context';
 
 export function SpeciesPDF() {
   const { id } = useParams<{ id: string }>();
-  const { hasDPADAccess } = useKeycloak();
   const { group, destineLayer, destineYear } = useSpeciesContext();
   const map = useMap();
 
@@ -39,7 +37,7 @@ export function SpeciesPDF() {
     queryFn: requestSpeciesArrowFn(group?.file)
   });
 
-  const destineDataEnabled = !!group?.id && hasDPADAccess && !!destineLayer;
+  const destineDataEnabled = !!group?.id && !!destineLayer;
   const { data: destineArrowData, isLoading: isDestineLoading } = useQuery({
     enabled: destineDataEnabled,
     queryKey: ['species', id, 'arrow-destine', group?.id],


### PR DESCRIPTION
Removes the dependency on DPAD access checks for determining whether to fetch and display species data.
